### PR TITLE
Readme version + flake8 errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,9 @@
 name: build
 
 on:
-  create:
+  push:
     branches:
       - 'master'
-    tags:
-      - '**'
   pull_request:
     branches:
       - master

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 torch_itl
 =========
 
+[![](https://github.com/allambert/torch_itl/workflows/build/badge.svg?branch=master)](https://github.com/allambert/torch_itl/actions?query=workflow%3Abuild)
+
 Algorithms for solving integral loss minimization problems. Currently, we handle the following problems:
 
 - Joint Quantile Regression
@@ -40,3 +42,7 @@ If you use this code, please cite the corresponding work:
   author={Lambert, Alex and Parekh, Sanjeel and Szab{\'o}, Zolt{\'a}n and d’Alch{\'e}-Buc, Florence},
   year={2021}
 }
+
+
+[1]:  https://github.com/allambert/torch_itl/workflows/build/badge.svg?branch=master
+[2]:  https://github.com/allambert/torch_itl/actions?query=workflow%3Abuild

--- a/demos/emotion_transfer/cross_validation.py
+++ b/demos/emotion_transfer/cross_validation.py
@@ -1,8 +1,6 @@
-# Cross validation script for tuning gamma_inp,
-# gamma_out, and lbda. Can take a while
-# ----------------------------------
-# Imports
-# ----------------------------------
+"""Cross validation script for tuning gamma_inp, gamma_out, and lbda.
+Can take a while."""
+
 import os
 import torch
 import matplotlib.pyplot as plt
@@ -25,7 +23,7 @@ from torch_itl.datasets import get_data_landmarks
 # ----------------------------------
 # Please replace those values with the right path to
 # the extracted landmarks on your computer.
-# See utils/README.md 
+# See utils/README.md
 path_to_rafd = '../../torch_itl/datasets/Rafd_Aligned/Rafd_LANDMARKS'
 path_to_kdef = '../../torch_itl/datasets/KDEF_Aligned/KDEF_LANDMARKS'
 # test of import
@@ -51,7 +49,7 @@ sampler = CircularEmoSampler()
 lbda = 2e-5
 # define the emotion transfer estimator
 est = EmoTransfer(model, lbda,  sampler, inp_emotion='joint')
-#%%
+# %%
 # ----------------------------------
 # Cross Validation Loop KDEF
 # ----------------------------------
@@ -59,25 +57,25 @@ print('Cross validation loop for KDEF')
 input_type_list = [i for i in range(m)] + ['joint']
 n_lbda = 10
 n_gamma_inp = 10
-n_gamma_out  = 10
-lbda_list = torch.logspace(-6,-3, n_lbda)
-gamma_inp_list = torch.logspace(-1.6,-0.5, n_gamma_inp)
-gamma_out_list = torch.logspace(-1.5,0, n_gamma_out)
+n_gamma_out = 10
+lbda_list = torch.logspace(-6, -3, n_lbda)
+gamma_inp_list = torch.logspace(-1.6, -0.5, n_gamma_inp)
+gamma_out_list = torch.logspace(-1.5, 0, n_gamma_out)
 risk_kdef = torch.zeros(m+1, 10, 6, n_lbda, n_gamma_inp, n_gamma_out)
 
 for n_input, input_type in enumerate(input_type_list):
-    print('Computing for input_type =', input_type, ', kfold = ', end= " ")
+    print('Computing for input_type =', input_type, ', kfold = ', end=" ")
     est.input_type = input_type
     for kfold in range(10):
         if kfold == 9:
             print(kfold)
         else:
-            print(kfold, end = " ")
+            print(kfold, end=" ")
         data, data_test = get_data_landmarks('KDEF', path_to_kdef, kfold=kfold)
         n = data.shape[0]
         mask = torch.randperm(n)
         for kval in range(6):
-            mask_train = ( mask >= 21*(kval+1)) + ( 21*kval > mask )
+            mask_train = (mask >= 21*(kval+1)) + (21*kval > mask)
             mask_val = (mask < 21*(kval+1))*(mask >= 21*kval)
             data_train = data[mask_train]
             data_val = data[mask_val]
@@ -88,8 +86,9 @@ for n_input, input_type in enumerate(input_type_list):
                     for k, gamma_out in enumerate(gamma_out_list):
                         est.model.kernel_output.gamma = gamma_out
                         est.fit(data_train)
-                        risk_kdef[n_input, kfold, kval, i, j, k] = est.risk(data_val)
-#%%
+                        risk_kdef[n_input, kfold, kval,
+                                  i, j, k] = est.risk(data_val)
+# %%
 print('Computing argmin')
 gamma_inp_argmin_kdef = torch.ones(m+1, 10)
 gamma_out_argmin_kdef = torch.ones(m+1, 10)
@@ -98,10 +97,13 @@ lbda_argmin_kdef = torch.ones(m+1, 10)
 for n_input in range(m+1):
     for kfold in range(10):
         t_kdef = risk_kdef[n_input, kfold].mean(0).argmin()
-        gamma_out_argmin_kdef[n_input, kfold] = gamma_out_list[t_kdef%n_gamma_out]
-        gamma_inp_argmin_kdef[n_input, kfold] = gamma_inp_list[(t_kdef//n_gamma_out)%n_gamma_inp]
-        lbda_argmin_kdef[n_input, kfold] = lbda_list[(t_kdef//n_gamma_out)//n_gamma_inp]
-#%%
+        gamma_out_argmin_kdef[n_input,
+                              kfold] = gamma_out_list[t_kdef % n_gamma_out]
+        gamma_inp_argmin_kdef[n_input, kfold] = gamma_inp_list[(
+            t_kdef//n_gamma_out) % n_gamma_inp]
+        lbda_argmin_kdef[n_input, kfold] = lbda_list[(
+            t_kdef//n_gamma_out)//n_gamma_inp]
+# %%
 print('Computing test risks with best parameters')
 test_risks_kdef = torch.zeros(m+1, 10)
 
@@ -111,20 +113,22 @@ for n_input, input_type in enumerate(input_type_list):
         est.lbda_reg = lbda_argmin_kdef[n_input, kfold]
         est.model.kernel_input.gamma = gamma_inp_argmin_kdef[n_input, kfold]
         est.model.kernel_output.gamma = gamma_out_argmin_kdef[n_input, kfold]
-        data_train, data_test = get_data_landmarks('KDEF', path_to_kdef, kfold=kfold)
+        data_train, data_test = get_data_landmarks(
+            'KDEF', path_to_kdef, kfold=kfold)
         est.fit(data_train)
         test_risks_kdef[n_input, kfold] = est.risk(data_test)
 
 test_means_kdef = test_risks_kdef.mean(1)
-test_stds_kdef = ((test_risks_kdef - test_means_kdef.view(-1,1))**2).mean(1).sqrt()
-#%%
+test_stds_kdef = (
+    (test_risks_kdef - test_means_kdef.view(-1, 1))**2).mean(1).sqrt()
+# %%
 print("Mean Test Errors KDEF:", test_means_kdef)
 print("Mean Test Stds KDEF:", test_stds_kdef)
-#%%
+# %%
 torch.save(lbda_argmin_kdef, 'KDEF_lbdas.pt')
 torch.save(gamma_inp_argmin_kdef, 'KDEF_gamma_inp.pt')
 torch.save(gamma_out_argmin_kdef, 'KDEF_gamma_out.pt')
-#%%
+# %%
 # ----------------------------------
 # Cross Validation Loop RaFD
 # ----------------------------------
@@ -132,25 +136,25 @@ print('Cross validation loop for RaFD:')
 input_type_list = [i for i in range(m)] + ['joint']
 n_lbda = 10
 n_gamma_inp = 10
-n_gamma_out  = 10
-lbda_list = torch.logspace(-6,-3, n_lbda)
-gamma_inp_list = torch.logspace(-1.6,-0.5, n_gamma_inp)
-gamma_out_list = torch.logspace(-1.5,0, n_gamma_out)
+n_gamma_out = 10
+lbda_list = torch.logspace(-6, -3, n_lbda)
+gamma_inp_list = torch.logspace(-1.6, -0.5, n_gamma_inp)
+gamma_out_list = torch.logspace(-1.5, 0, n_gamma_out)
 risk_rafd = torch.zeros(m+1, 10, 10, n_lbda, n_gamma_inp, n_gamma_out)
 
 for n_input, input_type in enumerate(input_type_list):
-    print('Computing for input_type =', input_type, ', kfold = ', end= " ")
+    print('Computing for input_type =', input_type, ', kfold = ', end=" ")
     est.input_type = input_type
-    for kfold in range(1,11):
+    for kfold in range(1, 11):
         if kfold == 10:
             print(kfold - 1)
         else:
-            print(kfold - 1, end = " ")
+            print(kfold - 1, end=" ")
         data, data_test = get_data_landmarks('RaFD', path_to_rafd, kfold=kfold)
         n = data.shape[0]
         mask = torch.randperm(n)
         for kval in range(10):
-            mask_train = ( mask >= 6*(kval+1)) + ( 6*kval > mask )
+            mask_train = (mask >= 6*(kval+1)) + (6*kval > mask)
             mask_val = (mask < 6*(kval+1))*(mask >= 6*kval)
             data_train = data[mask_train]
             data_val = data[mask_val]
@@ -161,8 +165,9 @@ for n_input, input_type in enumerate(input_type_list):
                     for k, gamma_out in enumerate(gamma_out_list):
                         est.model.kernel_output.gamma = gamma_out
                         est.fit(data_train)
-                        risk_rafd[n_input, kfold-1, kval, i, j, k] = est.risk(data_val)
-#%%
+                        risk_rafd[n_input, kfold-1, kval,
+                                  i, j, k] = est.risk(data_val)
+# %%
 print('Computing argmin')
 gamma_inp_argmin_rafd = torch.ones(m+1, 10)
 gamma_out_argmin_rafd = torch.ones(m+1, 10)
@@ -171,29 +176,34 @@ lbda_argmin_rafd = torch.ones(m+1, 10)
 for n_input in range(m+1):
     for kfold in range(10):
         t_rafd = risk_rafd[n_input, kfold].mean(0).argmin()
-        gamma_out_argmin_rafd[n_input, kfold] = gamma_out_list[t_rafd%n_gamma_out]
-        gamma_inp_argmin_rafd[n_input, kfold] = gamma_inp_list[(t_rafd//n_gamma_out)%n_gamma_inp]
-        lbda_argmin_rafd[n_input, kfold] = lbda_list[(t_rafd//n_gamma_out)//n_gamma_inp]
-#%%
+        gamma_out_argmin_rafd[n_input,
+                              kfold] = gamma_out_list[t_rafd % n_gamma_out]
+        gamma_inp_argmin_rafd[n_input, kfold] = gamma_inp_list[(
+            t_rafd//n_gamma_out) % n_gamma_inp]
+        lbda_argmin_rafd[n_input, kfold] = lbda_list[(
+            t_rafd//n_gamma_out)//n_gamma_inp]
+# %%
 print('Computing test risk for best parameters')
 test_risks_rafd = torch.zeros(m+1, 10)
 
 for n_input, input_type in enumerate(input_type_list):
     est.input_type = input_type
-    for kfold in range(1,11):
+    for kfold in range(1, 11):
         est.lbda = lbda_argmin_rafd[n_input, kfold-1]
         est.model.kernel_input.gamma = gamma_inp_argmin_rafd[n_input, kfold-1]
         est.model.kernel_output.gamma = gamma_out_argmin_rafd[n_input, kfold-1]
-        data_train, data_test = get_data_landmarks('RaFD', path_to_rafd, kfold=kfold)
+        data_train, data_test = get_data_landmarks(
+            'RaFD', path_to_rafd, kfold=kfold)
         est.fit(data_train)
         test_risks_rafd[n_input, kfold-1] = est.risk(data_test)
 
 test_means_rafd = test_risks_rafd.mean(1)
-test_stds_rafd = ((test_risks_rafd - test_means_rafd.view(-1,1))**2).mean(1).sqrt()
-#%%
+test_stds_rafd = (
+    (test_risks_rafd - test_means_rafd.view(-1, 1))**2).mean(1).sqrt()
+# %%
 print("Mean Test Errors RaFD:", test_means_rafd)
 print("Mean Test Stds RaFD:", test_stds_rafd)
-#%%
+# %%
 torch.save(lbda_argmin_rafd, 'Rafd_lbdas.pt')
 torch.save(gamma_inp_argmin_rafd, 'Rafd_gamma_inp.pt')
 torch.save(gamma_out_argmin_rafd, 'Rafd_gamma_out.pt')

--- a/demos/emotion_transfer/dim_reduction.py
+++ b/demos/emotion_transfer/dim_reduction.py
@@ -2,9 +2,7 @@
 # when using vITL by choosing A to be a non-invertible well chosen
 # matrix, built upon the empirical covariance matrix
 # Runtime ~1h on laptop
-# ----------------------------------
-# Imports
-# ----------------------------------
+
 import os
 import torch
 import matplotlib.pyplot as plt
@@ -26,7 +24,7 @@ from torch_itl.datasets import get_data_landmarks
 # ----------------------------------
 # Please replace those values with the right path to
 # the extracted landmarks on your computer.
-# See utils/README.md 
+# See utils/README.md
 path_to_rafd = '../../torch_itl/datasets/Rafd_Aligned/Rafd_LANDMARKS'
 path_to_kdef = '../../torch_itl/datasets/KDEF_Aligned/KDEF_LANDMARKS'
 # test of import
@@ -59,7 +57,8 @@ est = EmoTransfer(model, lbda,  sampler, inp_emotion='joint')
 print('Computing losses KDEF')
 losses_kdef = torch.zeros(10, nf)
 for kfold in range(10):
-    data_train, data_test = get_data_landmarks('KDEF', path_to_kdef, kfold=kfold)
+    data_train, data_test = get_data_landmarks(
+        'KDEF', path_to_kdef, kfold=kfold)
     for r in range(nf):
         est.fit_dim_red(data_train, r+1)
         losses_kdef[kfold, r] = est.risk(data_test)
@@ -69,8 +68,9 @@ for kfold in range(10):
 # ----------------------------------
 print('Computing losses RaFD')
 losses_rafd = torch.zeros(10, nf)
-for kfold in range(1,11):
-    data_train, data_test = get_data_landmarks('RaFD', path_to_rafd, kfold=kfold)
+for kfold in range(1, 11):
+    data_train, data_test = get_data_landmarks(
+        'RaFD', path_to_rafd, kfold=kfold)
     for r in range(nf):
         est.fit_dim_red(data_train, r+1)
         losses_rafd[kfold-1, r] = est.risk(data_test)
@@ -78,8 +78,8 @@ for kfold in range(1,11):
 # ----------------------------------
 # Saving the results
 # ----------------------------------
-#torch.save(losses_kdef,'dim_red_kdef.pt')
-#torch.save(losses_rafd,'dim_red_rafd.pt')
+# torch.save(losses_kdef,'dim_red_kdef.pt')
+# torch.save(losses_rafd,'dim_red_rafd.pt')
 # %%
 # ----------------------------------
 # Plotting
@@ -87,14 +87,16 @@ for kfold in range(1,11):
 std_rafd = ((losses_rafd - losses_rafd.mean(0))**2).mean(0).sqrt()
 std_kdef = ((losses_kdef - losses_kdef.mean(0))**2).mean(0).sqrt()
 plt.figure()
-plt.xlabel('Rank of $\mathbf{A}$')
+plt.xlabel(r'Rank of $\mathbf{A}$')
 plt.ylabel('Test MSE')
 plt.plot(losses_kdef.mean(0), c='black', label='KDEF mean', marker=',')
-plt.plot(losses_kdef.mean(0) + std_kdef, c='black', label='KDEF mean $\pm \sigma$', linestyle='--')
+plt.plot(losses_kdef.mean(0) + std_kdef, c='black',
+         label=r'KDEF mean $\pm \sigma$', linestyle='--')
 plt.plot(losses_kdef.mean(0) - std_kdef, c='black', linestyle='--')
-plt.plot(losses_rafd.mean(0), c= 'grey', label='RaFD mean', marker=',')
-plt.plot(losses_rafd.mean(0) + std_rafd, c= 'grey', label='RaFD mean $\pm \sigma$', linestyle='--')
-plt.plot(losses_rafd.mean(0) - std_rafd, c= 'grey', linestyle='--')
+plt.plot(losses_rafd.mean(0), c='grey', label='RaFD mean', marker=',')
+plt.plot(losses_rafd.mean(0) + std_rafd, c='grey',
+         label=r'RaFD mean $\pm \sigma$', linestyle='--')
+plt.plot(losses_rafd.mean(0) - std_rafd, c='grey', linestyle='--')
 
 plt.legend(loc='upper right')
 plt.savefig('dim_red.pdf')

--- a/demos/emotion_transfer/missing_data.py
+++ b/demos/emotion_transfer/missing_data.py
@@ -25,7 +25,7 @@ from torch_itl.datasets import get_data_landmarks
 # ----------------------------------
 # Please replace those values with the right path to
 # the extracted landmarks on your computer.
-# See utils/README.md 
+# See utils/README.md
 path_to_rafd = '../../torch_itl/datasets/Rafd_Aligned/Rafd_LANDMARKS'
 path_to_kdef = '../../torch_itl/datasets/KDEF_Aligned/KDEF_LANDMARKS'
 # test of import
@@ -51,7 +51,7 @@ sampler = CircularEmoSampler()
 lbda = 2e-5
 # define the emotion transfer estimator
 est = EmoTransfer(model, lbda,  sampler, inp_emotion='joint')
-#%%
+# %%
 # ----------------------------------
 # Learning in the presence of missing data -KDEF
 # ----------------------------------
@@ -72,7 +72,7 @@ for kfold in range(10):
             test_losses_kdef[kfold, j, i // 7] = est.risk(data_test)
     print('done with kfold ', kfold)
 # %%
-#torch.save(test_losses_kdef, 'kdef_partial.pt')
+# torch.save(test_losses_kdef, 'kdef_partial.pt')
 # %%
 # ----------------------------------
 # Learning in the presence of missing data -Rafd
@@ -94,28 +94,33 @@ for kfold in range(1, 11):
             mask = (mask_level >= i)
             est.fit_partial(data_train, mask)
             test_losses_rafd[kfold - 1, j, i // 7] = est.risk(data_test)
-#%%
-#torch.save(test_losses_rafd, 'rafd_partial.pt')
-#%%
-idx_kdef = torch.arange(test_losses_kdef.shape[2]*m)[::7].float() / test_losses_kdef.shape[2] / m
+# %%
+# torch.save(test_losses_rafd, 'rafd_partial.pt')
+# %%
+idx_kdef = torch.arange(
+    test_losses_kdef.shape[2]*m)[::7].float() / test_losses_kdef.shape[2] / m
 idx_rafd = torch.arange(test_losses_rafd.shape[2]*m)[::7].float() / n/m
-#%%
+# %%
 mean_kdef = test_losses_kdef.mean(1).mean(0)
-max_kdef , _ = test_losses_kdef.mean(1).max(axis=0)
-min_kdef , _ = test_losses_kdef.mean(1).min(axis=0)
+max_kdef, _ = test_losses_kdef.mean(1).max(axis=0)
+min_kdef, _ = test_losses_kdef.mean(1).min(axis=0)
 
 mean_rafd = test_losses_rafd.mean(1).mean(0)
-max_rafd , _ = test_losses_rafd.mean(1).max(axis=0)
-min_rafd , _ = test_losses_rafd.mean(1).min(axis=0)
-#%%
+max_rafd, _ = test_losses_rafd.mean(1).max(axis=0)
+min_rafd, _ = test_losses_rafd.mean(1).min(axis=0)
+# %%
 plt.figure()
 plt.xlabel("% of missing data")
 plt.ylabel("$\log_{10}$ Test MSE")
-plt.plot(idx_kdef, torch.log(mean_kdef), c='black', label='KDEF mean', marker=',')
-plt.plot(idx_kdef, torch.log(min_kdef), c='black', label='KDEF min-max', linestyle='--')
+plt.plot(idx_kdef, torch.log(mean_kdef),
+         c='black', label='KDEF mean', marker=',')
+plt.plot(idx_kdef, torch.log(min_kdef), c='black',
+         label='KDEF min-max', linestyle='--')
 plt.plot(idx_kdef, torch.log(max_kdef), c='black', linestyle='--')
-plt.plot(idx_rafd, torch.log(mean_rafd), c='grey', label='RaFD mean', marker=',')
-plt.plot(idx_rafd, torch.log(min_rafd), c='grey', label='RaFD min-max', linestyle='--')
+plt.plot(idx_rafd, torch.log(mean_rafd),
+         c='grey', label='RaFD mean', marker=',')
+plt.plot(idx_rafd, torch.log(min_rafd), c='grey',
+         label='RaFD min-max', linestyle='--')
 plt.plot(idx_rafd, torch.log(max_rafd), c='grey', linestyle='--')
 plt.legend(loc='upper left')
 plt.savefig('partial_observation.pdf')

--- a/demos/emotion_transfer/utils/dlib_landmarks.py
+++ b/demos/emotion_transfer/utils/dlib_landmarks.py
@@ -59,17 +59,26 @@ for f in file_list:
                                                   landmarks.part(1)))
         # Draw the face landmarks on the screen.
         # win.add_overlay(shape)
-    with open(os.path.join(output_folder, f.split('/')[-1].split('.')[0] + '.txt'), 'w') as file:
+    with open(os.path.join(
+            output_folder, f.split('/')[-1].split('.')[0] + '.txt'), 'w') as f:
         for pn in range(68):
-            file.write("{} {}\n".format(landmarks.part(pn).x,landmarks.part(pn).y)) 
+            f.write("{} {}\n".format(
+                landmarks.part(pn).x, landmarks.part(pn).y))
     # win.add_overlay(dets)
-    if draw_bool==1:
+    if draw_bool == 1:
         draw = ImageDraw.Draw(orig_image)
         colors = [(0, 0, 256)]
         for img_index_i in range(0, 68):
-            draw.line([landmarks.part(img_index_i).x, landmarks.part(img_index_i).y-4, landmarks.part(img_index_i).x, landmarks.part(img_index_i).y+4], fill=colors[0 % 5])
-            draw.line([landmarks.part(img_index_i).x-4, landmarks.part(img_index_i).y, landmarks.part(img_index_i).x+4, landmarks.part(img_index_i).y], fill=colors[0 % 5])
+            draw.line([landmarks.part(img_index_i).x,
+                       landmarks.part(img_index_i).y - 4,
+                       landmarks.part(img_index_i).x,
+                       landmarks.part(img_index_i).y + 4],
+                      fill=colors[0 % 5])
+            draw.line([landmarks.part(img_index_i).x - 4,
+                       landmarks.part(img_index_i).y,
+                       landmarks.part(img_index_i).x + 4,
+                       landmarks.part(img_index_i).y],
+                      fill=colors[0 % 5])
         plt.imshow(orig_image)
         plt.show()
         dlib.hit_enter_to_continue()
-

--- a/demos/emotion_transfer/utils/facealigner.py
+++ b/demos/emotion_transfer/utils/facealigner.py
@@ -1,4 +1,3 @@
-# import the necessary packages
 from collections import OrderedDict
 import subprocess
 import numpy as np
@@ -8,213 +7,208 @@ import os
 
 # For dlib’s 68-point facial landmark detector:
 FACIAL_LANDMARKS_68_IDXS = OrderedDict([
-	("mouth", (48, 68)),
-	("inner_mouth", (60, 68)),
-	("right_eyebrow", (17, 22)),
-	("left_eyebrow", (22, 27)),
-	("right_eye", (36, 42)),
-	("left_eye", (42, 48)),
-	("nose", (27, 36)),
-	("jaw", (0, 17))
+    ("mouth", (48, 68)),
+    ("inner_mouth", (60, 68)),
+    ("right_eyebrow", (17, 22)),
+    ("left_eyebrow", (22, 27)),
+    ("right_eye", (36, 42)),
+    ("left_eye", (42, 48)),
+    ("nose", (27, 36)),
+    ("jaw", (0, 17))
 ])
 
 
 class FaceAligner:
-	"""
-	Modified from python library imutils
-	"""
-	def __init__(self, desiredLeftEye=(0.35, 0.35),
-		desiredFaceWidth=256, desiredFaceHeight=None):
-		# store the facial landmark predictor, desired output left
-		# eye position, and desired output face width + height
+    """
+    Modified from python library imutils
+    """
 
-		self.desiredLeftEye = desiredLeftEye
-		self.desiredFaceWidth = desiredFaceWidth
-		self.desiredFaceHeight = desiredFaceHeight
+    def __init__(self, desiredLeftEye=(0.35, 0.35),
+                 desiredFaceWidth=256, desiredFaceHeight=None):
+        # store the facial landmark predictor, desired output left
+        # eye position, and desired output face width + height
 
-		# if the desired face height is None, set it to be the
-		# desired face width (normal behavior)
-		if self.desiredFaceHeight is None:
-			self.desiredFaceHeight = self.desiredFaceWidth
+        self.desiredLeftEye = desiredLeftEye
+        self.desiredFaceWidth = desiredFaceWidth
+        self.desiredFaceHeight = desiredFaceHeight
 
-	def align(self, image, shape):
-		# tight_aux = 10
-		# w = image.shape[1]
-		# h = image.shape[0]
-		# min_x = int(np.maximum(np.round(np.min(shape[:, 0])) - tight_aux, 0))
-		# min_y = int(np.maximum(np.round(np.min(shape[:, 1])) - tight_aux, 0))
-		# max_x = int(np.minimum(np.round(np.max(shape[:, 0])) + tight_aux, w - 1))
-		# max_y = int(np.minimum(np.round(np.max(shape[:, 1])) + tight_aux, h - 1))
-		# shape[:, 0] = shape[:, 0] - min_x
-		# shape[:, 1] = shape[:, 1] - min_y
+        # if the desired face height is None, set it to be the
+        # desired face width (normal behavior)
+        if self.desiredFaceHeight is None:
+            self.desiredFaceHeight = self.desiredFaceWidth
 
-		if len(shape) == 68:
-			# extract the left and right eye (x, y)-coordinates
-			(lStart, lEnd) = FACIAL_LANDMARKS_68_IDXS["left_eye"]
-			(rStart, rEnd) = FACIAL_LANDMARKS_68_IDXS["right_eye"]
+    def align(self, image, shape):
+        if len(shape) == 68:
+            # extract the left and right eye (x, y)-coordinates
+            (lStart, lEnd) = FACIAL_LANDMARKS_68_IDXS["left_eye"]
+            (rStart, rEnd) = FACIAL_LANDMARKS_68_IDXS["right_eye"]
 
-		leftEyePts = shape[lStart:lEnd]
-		rightEyePts = shape[rStart:rEnd]
+        leftEyePts = shape[lStart:lEnd]
+        rightEyePts = shape[rStart:rEnd]
 
-		# compute the center of mass for each eye
-		leftEyeCenter = leftEyePts.mean(axis=0).astype("int")
-		rightEyeCenter = rightEyePts.mean(axis=0).astype("int")
+        # compute the center of mass for each eye
+        leftEyeCenter = leftEyePts.mean(axis=0).astype("int")
+        rightEyeCenter = rightEyePts.mean(axis=0).astype("int")
 
-		# compute the angle between the eye centroids
-		dY = rightEyeCenter[1] - leftEyeCenter[1]
-		dX = rightEyeCenter[0] - leftEyeCenter[0]
-		angle = np.degrees(np.arctan2(dY, dX)) - 180
+        # compute the angle between the eye centroids
+        dY = rightEyeCenter[1] - leftEyeCenter[1]
+        dX = rightEyeCenter[0] - leftEyeCenter[0]
+        angle = np.degrees(np.arctan2(dY, dX)) - 180
 
-		# compute the desired right eye x-coordinate based on the
-		# desired x-coordinate of the left eye
-		desiredRightEyeX = 1.0 - self.desiredLeftEye[0]
+        # compute the desired right eye x-coordinate based on the
+        # desired x-coordinate of the left eye
+        desiredRightEyeX = 1.0 - self.desiredLeftEye[0]
 
-		# determine the scale of the new resulting image by taking
-		# the ratio of the distance between eyes in the *current*
-		# image to the ratio of distance between eyes in the
-		# *desired* image
-		dist = np.sqrt((dX ** 2) + (dY ** 2))
-		desiredDist = (desiredRightEyeX - self.desiredLeftEye[0])
-		desiredDist *= self.desiredFaceWidth
-		scale = desiredDist / dist
+        # determine the scale of the new resulting image by taking
+        # the ratio of the distance between eyes in the *current*
+        # image to the ratio of distance between eyes in the
+        # *desired* image
+        dist = np.sqrt((dX ** 2) + (dY ** 2))
+        desiredDist = (desiredRightEyeX - self.desiredLeftEye[0])
+        desiredDist *= self.desiredFaceWidth
+        scale = desiredDist / dist
 
-		# compute center (x, y)-coordinates (i.e., the median point)
-		# between the two eyes in the input image
-		eyesCenter = ((leftEyeCenter[0] + rightEyeCenter[0]) // 2,
-			(leftEyeCenter[1] + rightEyeCenter[1]) // 2)
+        # compute center (x, y)-coordinates (i.e., the median point)
+        # between the two eyes in the input image
+        eyesCenter = ((leftEyeCenter[0] + rightEyeCenter[0]) // 2,
+                      (leftEyeCenter[1] + rightEyeCenter[1]) // 2)
 
-		# grab the rotation matrix for rotating and scaling the face
-		M = cv2.getRotationMatrix2D(eyesCenter, angle, scale)
+        # grab the rotation matrix for rotating and scaling the face
+        M = cv2.getRotationMatrix2D(eyesCenter, angle, scale)
 
-		# update the translation component of the matrix
-		tX = self.desiredFaceWidth * 0.5
-		tY = self.desiredFaceHeight * self.desiredLeftEye[1]
-		M[0, 2] += (tX - eyesCenter[0])
-		M[1, 2] += (tY - eyesCenter[1])
+        # update the translation component of the matrix
+        tX = self.desiredFaceWidth * 0.5
+        tY = self.desiredFaceHeight * self.desiredLeftEye[1]
+        M[0, 2] += (tX - eyesCenter[0])
+        M[1, 2] += (tY - eyesCenter[1])
 
-		# apply the affine transformation
-		(w, h) = (self.desiredFaceWidth, self.desiredFaceHeight)
-		output = cv2.warpAffine(image, M, (w, h),
-			flags=cv2.INTER_CUBIC)
-		output_lnd = cv2.transform(shape[np.newaxis], M)
-		# return the aligned face and lnd
-		return output, np.squeeze(output_lnd)
+        # apply the affine transformation
+        (w, h) = (self.desiredFaceWidth, self.desiredFaceHeight)
+        output = cv2.warpAffine(image, M, (w, h),
+                                flags=cv2.INTER_CUBIC)
+        output_lnd = cv2.transform(shape[np.newaxis], M)
+        # return the aligned face and lnd
+        return output, np.squeeze(output_lnd)
 
 
 def list_and_landmarks(dataset, data_dir, lnd_dir, paths_txt, predictor_path):
 
-	# generate frontal faces list according to dataset
-	img_list = []
-	if dataset == 'KDEF':
-		for dir, subdir, filenames in os.walk(data_dir):
-			for f in filenames:
-				if f.endswith('S.JPG'):
-					img_list.append(os.path.join(dir, f))
-	elif dataset == 'Rafd':
-		for img in sorted(os.listdir(data_dir)):
-			print(img)
-			if img.split('.')[-1].lower() == 'jpg':
-				fname_part = img.split('.')[0].split('_')
-				print(fname_part)
-				if fname_part[5] == 'frontal' and fname_part[0][4:] == '090':
-					img_list.append(os.path.join(data_dir, img))
+    # generate frontal faces list according to dataset
+    img_list = []
+    if dataset == 'KDEF':
+        for dir, subdir, filenames in os.walk(data_dir):
+            for f in filenames:
+                if f.endswith('S.JPG'):
+                    img_list.append(os.path.join(dir, f))
+    elif dataset == 'Rafd':
+        for img in sorted(os.listdir(data_dir)):
+            print(img)
+            if img.split('.')[-1].lower() == 'jpg':
+                fname_part = img.split('.')[0].split('_')
+                print(fname_part)
+                if fname_part[5] == 'frontal' and fname_part[0][4:] == '090':
+                    img_list.append(os.path.join(data_dir, img))
 
-	with open(paths_txt, 'w') as f:
-		for fpath in img_list:
-			f.write('{}\n'.format(fpath))
+    with open(paths_txt, 'w') as f:
+        for fpath in img_list:
+            f.write('{}\n'.format(fpath))
 
-	# get landmarks from dlib
-	if not os.path.exists(predictor_path):
-		print('Landmarks predictor does not exist.')
-	else:
-		dlib_cmd = ' '.join(['python dlib_landmarks.py', predictor_path, paths_txt, lnd_dir])
-		with subprocess.Popen(dlib_cmd, shell=True, stdout=subprocess.PIPE) as cmd:
-			for line in cmd.stdout:
-				print(line)
-	return img_list
+    # get landmarks from dlib
+    if not os.path.exists(predictor_path):
+        print('Landmarks predictor does not exist.')
+    else:
+        dlib_cmd = ' '.join(['python dlib_landmarks.py',
+                             predictor_path, paths_txt, lnd_dir])
+        with subprocess.Popen(dlib_cmd, shell=True, stdout=subprocess.PIPE) as cmd:
+            for line in cmd.stdout:
+                print(line)
+    return img_list
 
 
 def data_preprocess(dataset, data_dir, dest_base_dir, predictor_path):
+    """
+    Parameters
+    ----------
+    dataset: str
+                    KDEF or Rafd, dataset names
+    data_dir: str
+                    path to data directory to fetch images
+    dest_base_dir:
+                    directory to store all outputs
+    predictor_path:
+                    predictor for computing dlib landmarks
+                    Download from http://dlib.net/files/shape_predictor_68_face_landmarks.dat.bz2
 
-	"""
-	Parameters
-	----------
-	dataset: str
-			KDEF or Rafd, dataset names
-	data_dir: str
-			path to data directory to fetch images
-	dest_base_dir:
-			directory to store all outputs
-	predictor_path:
-			predictor for computing dlib landmarks
-			Download from http://dlib.net/files/shape_predictor_68_face_landmarks.dat.bz2
+    Returns
+    -------
+    Saves all dlib landmarks, aligned images/landmarks in dedicated folders on dest_base_dir
+    """
 
-	Returns
-	-------
-	Saves all dlib landmarks, aligned images/landmarks in dedicated folders on dest_base_dir
-	"""
+    print('COMPUTING LANDMARKS')
+    # create file list, compute landmarks and return with list for alignment
+    lnd_dir = os.path.join(dest_base_dir, dataset + '_LANDMARKS')
+    paths_txt = os.path.join(dest_base_dir, dataset + '_frontal_list.txt')
+    if not os.path.exists(lnd_dir):
+        os.makedirs(lnd_dir)
+    img_list = list_and_landmarks(
+        dataset, data_dir, lnd_dir, paths_txt, predictor_path)
 
-	print('COMPUTING LANDMARKS')
-	# create file list, compute landmarks and return with list for alignment
-	lnd_dir = os.path.join(dest_base_dir, dataset + '_LANDMARKS')
-	paths_txt = os.path.join(dest_base_dir, dataset + '_frontal_list.txt')
-	if not os.path.exists(lnd_dir):
-		os.makedirs(lnd_dir)
-	img_list = list_and_landmarks(dataset, data_dir, lnd_dir, paths_txt, predictor_path)
+    print('PERFORMING ALIGNMENT')
+    # init aligner
+    fa = FaceAligner(desiredFaceWidth=128)
 
-	print('PERFORMING ALIGNMENT')
-	# init aligner
-	fa = FaceAligner(desiredFaceWidth=128)
+    # destination directory structure
+    dest_parent_folder_path = os.path.join(dest_base_dir, dataset + '_Aligned')
+    dest_sub_folder_datapath = os.path.join(dest_parent_folder_path, dataset)
+    dest_sub_folder_lndpath = os.path.join(
+        dest_parent_folder_path, dataset + '_LANDMARKS')
 
-	# destination directory structure
-	dest_parent_folder_path = os.path.join(dest_base_dir, dataset + '_Aligned')
-	dest_sub_folder_datapath = os.path.join(dest_parent_folder_path, dataset)
-	dest_sub_folder_lndpath = os.path.join(dest_parent_folder_path, dataset + '_LANDMARKS')
+    if not os.path.exists(dest_parent_folder_path):
+        os.makedirs(dest_sub_folder_datapath)
+        os.makedirs(dest_sub_folder_lndpath)
 
-	if not os.path.exists(dest_parent_folder_path):
-		os.makedirs(dest_sub_folder_datapath)
-		os.makedirs(dest_sub_folder_lndpath)
+    for index, row in enumerate(img_list):
 
-	for index, row in enumerate(img_list):
+        # read each image and landmarks
+        # ----file paths
+        im_path = row
+        file_name = row.split('/')[-1].split('.')[0]
+        lnd_file_path = os.path.join(lnd_dir, file_name + '.txt')
 
-		# read each image and landmarks
-		# ----file paths
-		im_path = row
-		file_name = row.split('/')[-1].split('.')[0]
-		lnd_file_path = os.path.join(lnd_dir, file_name + '.txt')
+        # ----read_image
+        image = cv2.imread(im_path)
 
-		# ----read_image
-		image = cv2.imread(im_path)
+        # get landmarks
+        points = np.loadtxt(lnd_file_path).reshape(68, 2)
 
-		# get landmarks
-		points = np.loadtxt(lnd_file_path).reshape(68, 2)
+        # compute alignment
+        image_aligned, points_aligned = fa.align(image, points)
 
-		# compute alignment
-		image_aligned, points_aligned = fa.align(image, points)
+        # store back in a folder structure similar to Rafd
+        row_impath = os.path.join(dest_sub_folder_datapath, file_name + '.JPG')
+        row_lndpath = os.path.join(dest_sub_folder_lndpath, file_name + '.txt')
 
-		# store back in a folder structure similar to Rafd
-		row_impath = os.path.join(dest_sub_folder_datapath, file_name + '.JPG')
-		row_lndpath = os.path.join(dest_sub_folder_lndpath, file_name + '.txt')
-
-		cv2.imwrite(row_impath, image_aligned)
-		with open(row_lndpath, 'w') as file:
-			for idx_l in range(68):
-				file.write("{} {}\n".format(points_aligned[idx_l, 0], points_aligned[idx_l, 1]))
+        cv2.imwrite(row_impath, image_aligned)
+        with open(row_lndpath, 'w') as file:
+            for idx_l in range(68):
+                file.write("{} {}\n".format(
+                    points_aligned[idx_l, 0], points_aligned[idx_l, 1]))
 
 
 if __name__ == "__main__":
-	# download from http://dlib.net/files/shape_predictor_68_face_landmarks.dat.bz2
-	predictor_path = 'shape_predictor_68_face_landmarks.dat'
+    # DL from http://dlib.net/files/shape_predictor_68_face_landmarks.dat.bz2
+    predictor_path = 'shape_predictor_68_face_landmarks.dat'
 
-	dataset = 'KDEF'
-	data_dir = 'PATH_TO_KDEF'
-	dest_dir = 'DESTINATION PATH'
+    dataset = 'KDEF'
+    data_dir = 'PATH_TO_KDEF'
+    dest_dir = 'DESTINATION PATH'
 
-	# dataset = 'Rafd'
-	# data_dir = 'PATH_TO_Rafd'
-	# dest_dir = 'DESTINATION PATH'
+    # dataset = 'Rafd'
+    # data_dir = 'PATH_TO_Rafd'
+    # dest_dir = 'DESTINATION PATH'
 
-	# change dest dir to be compatible with other scripts and store in right location
-	# dest_dir = '../../../torch_itl/datasets'
+    # change dest dir to be compatible with other scripts and store in
+    # right location
+    # dest_dir = '../../../torch_itl/datasets'
 
-	data_preprocess(dataset, data_dir, dest_dir, predictor_path)
+    data_preprocess(dataset, data_dir, dest_dir, predictor_path)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,14 @@
-from setuptools import setup
+import os
+from setuptools import setup, find_packages
+
+version = None
+with open(os.path.join('torch_itl', '__init__.py'), 'r') as fid:
+    for line in (line.strip() for line in fid):
+        if line.startswith('__version__'):
+            version = line.split('=')[1].strip().strip('\'')
+            break
+if version is None:
+    raise RuntimeError('Could not determine version')
 
 
 def parse_requirements(filename):
@@ -12,13 +22,12 @@ install_reqs = parse_requirements('./requirements.txt')
 reqs = [str(ir) for ir in install_reqs]
 
 setup(name='torch_itl',
-      version='0.1dev',
+      version=version,
       description='pytorch compatible integral loss minimization',
       author='Alex Lambert',
       author_email='alex.lambert@protonmail.com',
       license='MIT',
-      packages=['torch_itl', 'torch_itl.estimator', 'torch_itl.kernel',
-                'torch_itl.model', 'torch_itl.sampler', 'torch_itl.datasets'],
+      packages=find_packages(),
       include_package_data=True,
       install_requires=reqs,
       zip_safe=False)

--- a/torch_itl/__init__.py
+++ b/torch_itl/__init__.py
@@ -2,3 +2,6 @@ from .kernel import *
 from .model import *
 from .sampler import *
 from .estimator import *
+
+
+__version__ = '0.1.dev'

--- a/torch_itl/datasets/datasets.py
+++ b/torch_itl/datasets/datasets.py
@@ -1,9 +1,12 @@
+import random
 import os
 import torch
 import numpy as np
-np.random.seed(seed=21)
-import random
+import pandas as pd
+
 from .synthetic_quantile import toy_data_quantile
+
+np.random.seed(seed=21)
 
 
 def import_data_otoliths():
@@ -60,20 +63,22 @@ def import_toy_synthesis(n_samples, n_theta):
         torch.from_numpy(x_test).float(), torch.from_numpy(y_test).float()
 
 
-def kdef_landmarks_facealigner(path_to_landmarks, inp_emotion='NE', inc_emotion=False,
-                               kfold=0, random_seed=21):
+def kdef_landmarks_facealigner(
+        path_to_landmarks, inp_emotion='NE', inc_emotion=False, kfold=0,
+        random_seed=21):
     """
     Get data to train vITL for KDEF
     Parameters
     ----------
     path_to_landmarks: str
-                       path to folder containing landmarks
+        path to folder containing landmarks
     inp_emotion: str
-                 the input emotion for single model
+        the input emotion for single model
     inc_emotion: bool
-                 whether to include inp_emotion in output
+        whether to include inp_emotion in output
     kfold: int
-           which split to compute data for, 0 is a preselected split, start from 1
+        which split to compute data for, 0 is a preselected split,
+        start from 1
     random_seed: set to 21 for reproducibility
 
     Returns
@@ -96,7 +101,8 @@ def kdef_landmarks_facealigner(path_to_landmarks, inp_emotion='NE', inc_emotion=
         shuffle_all_ids = all_ids.copy()
         random.Random(random_seed).shuffle(shuffle_all_ids)
         test_num = len(shuffle_all_ids)//10  # 90/10 split
-        test_identities = shuffle_all_ids[(kfold - 1) * test_num:kfold * test_num]
+        test_identities = shuffle_all_ids[(
+            kfold - 1) * test_num:kfold * test_num]
 
     # define emotion list, same as in sampler (different abbrv. due to dataset)
     all_emotions = ['AN', 'DI', 'AF', 'HA', 'SA', 'SU', 'NE']
@@ -126,21 +132,25 @@ def kdef_landmarks_facealigner(path_to_landmarks, inp_emotion='NE', inc_emotion=
 
     # read input/output train
     for row in train_list:
-        tmp_ne = np.loadtxt(os.path.join(path_to_landmarks, row[0])).reshape(68, 2)
+        tmp_ne = np.loadtxt(os.path.join(
+            path_to_landmarks, row[0])).reshape(68, 2)
         train_input.append(tmp_ne.flatten())
         tmp_ems = []
         for row_em in row[1]:
-            tmp_em = np.loadtxt(os.path.join(path_to_landmarks, row_em)).reshape(68, 2)
+            tmp_em = np.loadtxt(os.path.join(
+                path_to_landmarks, row_em)).reshape(68, 2)
             tmp_ems.append(tmp_em.flatten())
         train_output.append(tmp_ems)
 
     # read input/output test
     for row in test_list:
-        tmp_ne = np.loadtxt(os.path.join(path_to_landmarks, row[0])).reshape(68,2)
+        tmp_ne = np.loadtxt(os.path.join(
+            path_to_landmarks, row[0])).reshape(68, 2)
         test_input.append(tmp_ne.flatten())
         tmp_ems = []
         for row_em in row[1]:
-            tmp_em = np.loadtxt(os.path.join(path_to_landmarks, row_em)).reshape(68, 2)
+            tmp_em = np.loadtxt(os.path.join(
+                path_to_landmarks, row_em)).reshape(68, 2)
             tmp_ems.append(tmp_em.flatten())
         test_output.append(tmp_ems)
 
@@ -151,26 +161,29 @@ def kdef_landmarks_facealigner(path_to_landmarks, inp_emotion='NE', inc_emotion=
     test_input = np.array(test_input) / im_size
     test_output = np.array(test_output) / im_size
 
-    return torch.from_numpy(train_input).float(), torch.from_numpy(train_output).float(),\
-           torch.from_numpy(test_input).float(), torch.from_numpy(test_output).float(), \
-           train_list, test_list
+    return (torch.from_numpy(train_input).float(),
+            torch.from_numpy(train_output).float(),
+            torch.from_numpy(test_input).float(),
+            torch.from_numpy(test_output).float(),
+            train_list, test_list)
 
 
-def rafd_landmarks_facealigner(path_to_landmarks, inp_emotion='neutral', inc_emotion=False,
-                               kfold=0, random_seed=21):
+def rafd_landmarks_facealigner(
+        path_to_landmarks, inp_emotion='neutral', inc_emotion=False, kfold=0,
+        random_seed=21):
     """
     Get data to train vITL for RaFD
 
     Parameters
     ----------
     path_to_landmarks: str
-                       path to folder cotaining landmarks
+        path to folder cotaining landmarks
     inp_emotion: str
-                 the input emotion for single model
+        the input emotion for single model
     inc_emotion: bool
-                 whether to include inp_emotion in output
+        whether to include inp_emotion in output
     kfold: int
-           which split to compute data for, 0 is a preselected split, start from 1
+        which split to compute data for, 0 is a preselected split, start from 1
     random_seed: set to 21 for reproducibility
 
     Returns
@@ -180,12 +193,14 @@ def rafd_landmarks_facealigner(path_to_landmarks, inp_emotion='neutral', inc_emo
 
     train_list = []
     test_list = []
-    all_ids = ['01', '02', '03', '04', '05', '07', '08', '09', '10', '11', '12',
-               '14', '15', '16', '18', '19', '20', '21', '22', '23', '24', '25',
-               '26', '27', '28', '29', '30', '31', '32', '33', '35', '36', '37',
-               '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48',
-               '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59',
-               '60', '61', '63', '64', '65', '67', '68', '69', '70', '71', '72', '73']
+    all_ids = [
+        '01', '02', '03', '04', '05', '07', '08', '09', '10', '11', '12',
+        '14', '15', '16', '18', '19', '20', '21', '22', '23', '24', '25',
+        '26', '27', '28', '29', '30', '31', '32', '33', '35', '36', '37',
+        '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48',
+        '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59',
+        '60', '61', '63', '64', '65', '67', '68', '69', '70', '71', '72',
+        '73']
 
     # set test identities
     if kfold == 0:
@@ -196,7 +211,8 @@ def rafd_landmarks_facealigner(path_to_landmarks, inp_emotion='neutral', inc_emo
         test_num = len(shuffle_all_ids) // 10  # 90/10 split
         test_ids = shuffle_all_ids[(kfold - 1) * test_num:kfold * test_num]
 
-    all_emotions = ['angry', 'contemptuous', 'disgusted', 'fearful', 'happy', 'sad', 'surprised', 'neutral']
+    all_emotions = ['angry', 'contemptuous', 'disgusted',
+                    'fearful', 'happy', 'sad', 'surprised', 'neutral']
 
     inp_emo_idx = all_emotions.index(inp_emotion)
     num_emos = len(all_emotions)
@@ -210,7 +226,8 @@ def rafd_landmarks_facealigner(path_to_landmarks, inp_emotion='neutral', inc_emo
         con_im = fnames.pop(1)
 
         assert set([fn[8:10] for fn in fnames]) == set([all_ids[i]])
-        assert set([fn.split('_')[4] for fn in fnames]) == set(all_emotions)- {'contemptuous'}
+        assert set([fn.split('_')[4] for fn in fnames]) == set(
+            all_emotions) - {'contemptuous'}
 
         if inp_emo_idx > 1:
             inp_im = fnames[inp_emo_idx-1]
@@ -231,21 +248,25 @@ def rafd_landmarks_facealigner(path_to_landmarks, inp_emotion='neutral', inc_emo
 
     # read input/output train
     for row in train_list:
-        tmp_ne = np.loadtxt(os.path.join(path_to_landmarks, row[0])).reshape(68, 2)
+        tmp_ne = np.loadtxt(os.path.join(
+            path_to_landmarks, row[0])).reshape(68, 2)
         train_input.append(tmp_ne.flatten())
         tmp_ems = []
         for row_em in row[1]:
-            tmp_em = np.loadtxt(os.path.join(path_to_landmarks, row_em)).reshape(68, 2)
+            tmp_em = np.loadtxt(os.path.join(
+                path_to_landmarks, row_em)).reshape(68, 2)
             tmp_ems.append(tmp_em.flatten())
         train_output.append(tmp_ems)
 
     # read input/output test
     for row in test_list:
-        tmp_ne = np.loadtxt(os.path.join(path_to_landmarks, row[0])).reshape(68,2)
+        tmp_ne = np.loadtxt(os.path.join(
+            path_to_landmarks, row[0])).reshape(68, 2)
         test_input.append(tmp_ne.flatten())
         tmp_ems = []
         for row_em in row[1]:
-            tmp_em = np.loadtxt(os.path.join(path_to_landmarks, row_em)).reshape(68, 2)
+            tmp_em = np.loadtxt(os.path.join(
+                path_to_landmarks, row_em)).reshape(68, 2)
             tmp_ems.append(tmp_em.flatten())
         test_output.append(tmp_ems)
 
@@ -256,8 +277,8 @@ def rafd_landmarks_facealigner(path_to_landmarks, inp_emotion='neutral', inc_emo
     test_input = np.array(test_input) / im_size
     test_output = np.array(test_output) / im_size
     return torch.from_numpy(train_input).float(), torch.from_numpy(train_output).float(), \
-           torch.from_numpy(test_input).float(), torch.from_numpy(test_output).float(), \
-           train_list, test_list
+        torch.from_numpy(test_input).float(), torch.from_numpy(test_output).float(), \
+        train_list, test_list
 
 
 def get_data_landmarks(dataset, path_to_landmarks, kfold=0, random_seed=21):
@@ -277,18 +298,23 @@ def get_data_landmarks(dataset, path_to_landmarks, kfold=0, random_seed=21):
     -------
     data_train, data_test
     '''
-    if dataset=='KDEF':
-        x_train, y_train, x_test, y_test, train_list, test_list = kdef_landmarks_facealigner(
-            path_to_landmarks, inp_emotion='AN', inc_emotion=True, kfold=kfold, random_seed=random_seed)
+    if dataset == 'KDEF':
+        x_train, y_train, x_test, y_test, train_list, test_list = \
+            kdef_landmarks_facealigner(
+                path_to_landmarks, inp_emotion='AN', inc_emotion=True,
+                kfold=kfold, random_seed=random_seed)
 
-    elif dataset=='RaFD':
-        x_train, y_train, x_test, y_test, train_list, test_list = rafd_landmarks_facealigner(
-            path_to_landmarks, inp_emotion='angry', inc_emotion=True, kfold=kfold, random_seed=random_seed)
+    elif dataset == 'RaFD':
+        x_train, y_train, x_test, y_test, train_list, test_list = \
+            rafd_landmarks_facealigner(
+                path_to_landmarks, inp_emotion='angry', inc_emotion=True,
+                kfold=kfold, random_seed=random_seed)
 
     else:
         raise Exception('Unknown dataset')
 
     return y_train, y_test
+
 
 def import_affectnet_va_embedding(affect_net_csv_path):
     if not affect_net_csv_path == '':
@@ -307,11 +333,11 @@ def import_affectnet_va_embedding(affect_net_csv_path):
                                      df[df[6] == key][8].mean()]
     else:
         emo_va = {'Neutral': [-0.06249655698883391, -0.019669702033559486],
-         'Happy': [0.6647930758154823, 0.07025315235958239],
-         'Sad': [-0.6364936709598201, -0.25688320447600566],
-         'Surprise': [0.17960005233680493, 0.6894792038743631],
-         'Fear': [-0.1253752865553082, 0.7655788112100937],
-         'Disgust': [-0.6943645673378837, 0.457145871269001],
-         'Anger': [-0.452336028803629, 0.5656012294430937],
-         'Contempt': [-0.5138537435929467, 0.5825553992724378]}
+                  'Happy': [0.6647930758154823, 0.07025315235958239],
+                  'Sad': [-0.6364936709598201, -0.25688320447600566],
+                  'Surprise': [0.17960005233680493, 0.6894792038743631],
+                  'Fear': [-0.1253752865553082, 0.7655788112100937],
+                  'Disgust': [-0.6943645673378837, 0.457145871269001],
+                  'Anger': [-0.452336028803629, 0.5656012294430937],
+                  'Contempt': [-0.5138537435929467, 0.5825553992724378]}
     return emo_va

--- a/torch_itl/datasets/datasets.py
+++ b/torch_itl/datasets/datasets.py
@@ -59,8 +59,10 @@ def import_toy_synthesis(n_samples, n_theta):
     y_train = Y[0:n_samples//2]
     x_test = X[n_samples//2:]
     y_test = Y[n_samples//2:]
-    return torch.from_numpy(x_train).float(), torch.from_numpy(y_train).float(), \
-        torch.from_numpy(x_test).float(), torch.from_numpy(y_test).float()
+    return (torch.from_numpy(x_train).float(),
+            torch.from_numpy(y_train).float(),
+            torch.from_numpy(x_test).float(),
+            torch.from_numpy(y_test).float())
 
 
 def kdef_landmarks_facealigner(
@@ -276,9 +278,11 @@ def rafd_landmarks_facealigner(
     train_output = np.array(train_output) / im_size
     test_input = np.array(test_input) / im_size
     test_output = np.array(test_output) / im_size
-    return torch.from_numpy(train_input).float(), torch.from_numpy(train_output).float(), \
-        torch.from_numpy(test_input).float(), torch.from_numpy(test_output).float(), \
-        train_list, test_list
+    return (torch.from_numpy(train_input).float(),
+            torch.from_numpy(train_output).float(),
+            torch.from_numpy(test_input).float(),
+            torch.from_numpy(test_output).float(),
+            train_list, test_list)
 
 
 def get_data_landmarks(dataset, path_to_landmarks, kfold=0, random_seed=21):
@@ -291,7 +295,8 @@ def get_data_landmarks(dataset, path_to_landmarks, kfold=0, random_seed=21):
     path_to_landmarks: str
                        path to folder cotaining landmarks
     kfold: int
-           which split to compute data for, 0 is a preselected split, start from 1
+           which split to compute data for, 0 is a preselected split, \
+               start from 1
     random_seed: set to 21 for reproducibility
 
     Returns

--- a/torch_itl/estimator/utils.py
+++ b/torch_itl/estimator/utils.py
@@ -19,7 +19,9 @@ def bst(alpha, tau):
 
 
 def iht(alpha, tau):
-    return torch.where(alpha.abs() - tau < 0, torch.zeros_like(alpha), alpha.abs() - tau) * torch.sign(alpha)
+    return torch.where(alpha.abs() - tau < 0,
+                       torch.zeros_like(alpha),
+                       alpha.abs() - tau) * torch.sign(alpha)
 
 
 def squared_norm(y_true, y_pred, thetas, mask=None):
@@ -49,9 +51,11 @@ def ploss(y_true, y_pred, probs):
                      (probs - 1).view(-1) * residual).sum() / n / m
     return(loss)
 
-def ploss_dual(res,thetas):
-    condition = (res < thetas) & (res >  thetas - 1)
+
+def ploss_dual(res, thetas):
+    condition = (res < thetas) & (res > thetas - 1)
     return torch.where(condition, 0, sys.float_info.max)
+
 
 def closs(y_pred):
     """Compute the crossing loss.

--- a/torch_itl/estimator/vitl.py
+++ b/torch_itl/estimator/vitl.py
@@ -2,6 +2,7 @@ import torch
 import time
 import torch.optim as optim
 
+
 class VITL(object):
     """Implements VITL
     It is a vectorial outputs extension to ITL, proposed in
@@ -102,7 +103,8 @@ class VITL(object):
             raise Exception('No training data provided')
         return self.risk(self.model.x_train, self.model.y_train)
 
-    def fit_alpha_gd(self, x, y, n_epochs=500, solver=torch.optim.LBFGS, warm_start=True, **kwargs):
+    def fit_alpha_gd(self, x, y, n_epochs=500, solver=torch.optim.LBFGS,
+                     warm_start=True, **kwargs):
         """
         Fits the parameters alpha of the model, based on the representer theorem
         with gradient descent
@@ -159,8 +161,8 @@ class VITL(object):
 
     def fit_kernel_input(self, x, y, n_epochs=150):
         """
-        Fits the parameters of the neural network associated to the input kernel
-        (deep kernel learning) with gradient descent
+        Fits the parameters of the neural network associated to the input
+        kernel (deep kernel learning) with gradient descent
         Parameters
         ----------
         x: torch.Tensor of shape (n_samples, n_features_1)
@@ -206,8 +208,8 @@ class VITL(object):
 
     def fit_kernel_output(self, x, y, n_epochs=150):
         """
-        Fits the parameters of the neural network associated to the output kernel
-        (deep kernel learning)
+        Fits the parameters of the neural network associated to the output
+        kernel (deep kernel learning)
         Parameters
         ----------
         x: torch.Tensor of shape (n_samples, n_features_1)

--- a/torch_itl/kernel/kernel.py
+++ b/torch_itl/kernel/kernel.py
@@ -1,8 +1,9 @@
 import torch
+
 from .utils import rbf_kernel, get_anchors_gaussian_rff
 
-class Gaussian(object):
 
+class Gaussian(object):
     def __init__(self, gamma):
         self.gamma = gamma
         self.is_learnable = False
@@ -12,7 +13,6 @@ class Gaussian(object):
 
 
 class GaussianRFF(object):
-
     def __init__(self, dim_input, dim_rff, gamma):
         self.dim_rff = dim_rff
         self.is_learnable = False
@@ -22,7 +22,8 @@ class GaussianRFF(object):
     def feature_map(self, X):
         a = torch.cos(X @ self.anchors)
         b = torch.sin(X @ self.anchors)
-        return 1 / torch.sqrt(torch.Tensor([self.dim_rff])) * torch.cat((a, b), 1)
+        return 1 / torch.sqrt(torch.Tensor([self.dim_rff])) * \
+            torch.cat((a, b), 1)
 
 
 class Linear(object):

--- a/torch_itl/kernel/learnable.py
+++ b/torch_itl/kernel/learnable.py
@@ -1,4 +1,5 @@
 import torch
+
 from .kernel import Gaussian, GaussianRFF, Linear
 
 
@@ -14,7 +15,8 @@ class LearnableKernel(object):
         if Y is None:
             return self.kernel.compute_gram(self.model.forward(X), Y=None)
         else:
-            return self.kernel.compute_gram(self.model.forward(X), self.model.forward(Y))
+            return self.kernel.compute_gram(
+                self.model.forward(X), self.model.forward(Y))
 
     def regularization(self):
         return 0
@@ -22,20 +24,24 @@ class LearnableKernel(object):
     def clear_memory(self):
         self.losses, self.times = [], [0]
 
+
 class LearnableLinear(LearnableKernel):
 
     def __init__(self, model, optim_params):
         super().__init__(Linear, model, optim_params)
+
 
 class LearnableGaussian(LearnableKernel):
 
     def __init__(self, gamma, model, optim_params):
         super().__init__(Gaussian(gamma), model, optim_params)
 
+
 class LearnableGaussianRFF(LearnableKernel):
 
     def __init__(self, gamma, model, dim_model_output, dim_rff, optim_params):
-        super().__init__(GaussianRFF(dim_model_output, dim_rff, gamma), model, optim_params)
+        super().__init__(GaussianRFF(dim_model_output, dim_rff, gamma),
+                         model, optim_params)
 
     def feature_map(self, X):
         return self.kernel.feature_map(self.model.forward(X))

--- a/torch_itl/kernel/utils.py
+++ b/torch_itl/kernel/utils.py
@@ -1,5 +1,6 @@
 import torch
 
+
 def rbf_kernel(X, Y=None, gamma=None):
     """Compute rbf Gram matrix between X and Y (or X)
     courtesy of plaforgue

--- a/torch_itl/model/decomposable.py
+++ b/torch_itl/model/decomposable.py
@@ -2,8 +2,11 @@ import torch
 
 
 def kron(matrix1, matrix2):
-    return torch.ger(matrix1.view(-1), matrix2.view(-1)).reshape(*(matrix1.size() + matrix2.size())).permute(
-        [0, 2, 1, 3]).reshape(matrix1.size(0) * matrix2.size(0), matrix1.size(1) * matrix2.size(1))
+    return torch.ger(
+        matrix1.view(-1),
+        matrix2.view(-1)).reshape(*(matrix1.size() + matrix2.size())).permute(
+        [0, 2, 1, 3]).reshape(matrix1.size(0) * matrix2.size(0),
+                              matrix1.size(1) * matrix2.size(1))
 
 
 class Decomposable(object):
@@ -20,7 +23,7 @@ class Decomposable(object):
 
     def compute_gram(self, x, thetas):
         """
-        Computes and stores the gram matrices of the model anchors and (x,thetas)
+        Compute and store the gram matrices of the model anchors and (x,thetas)
         Parameters
         ----------
         x:  torch.Tensor of shape (n_samples, n_features_1)
@@ -30,7 +33,8 @@ class Decomposable(object):
             default: locations used when learning
         Returns
         -------
-        G_xt: torch.Tensor of shape (n_samples * n_anchors, n_samples * n_anchors)
+        G_xt: torch.Tensor, \
+                shape (n_samples * n_anchors, n_samples * n_anchors)
             Gram matrix used for predictions
         """
         G_x = self.kernel_input.compute_gram(x, self.x_train)


### PR DESCRIPTION
@allambert some remaining:
```
(base) ➜  torch_itl git:(readme_version) ✗ flake8
./torch_itl/__init__.py:1:1: F403 'from .kernel import *' used; unable to detect undefined names
./torch_itl/__init__.py:1:1: F401 '.kernel.*' imported but unused
./torch_itl/__init__.py:2:1: F403 'from .model import *' used; unable to detect undefined names
./torch_itl/__init__.py:2:1: F401 '.model.*' imported but unused
./torch_itl/__init__.py:3:1: F403 'from .sampler import *' used; unable to detect undefined names
./torch_itl/__init__.py:3:1: F401 '.sampler.*' imported but unused
./torch_itl/__init__.py:4:1: F403 'from .estimator import *' used; unable to detect undefined names
./torch_itl/__init__.py:4:1: F401 '.estimator.*' imported but unused
./torch_itl/model/decomposable.py:14:45: W605 invalid escape sequence '\T'
./torch_itl/model/__init__.py:1:1: F401 '.decomposable.Decomposable' imported but unused
./torch_itl/model/__init__.py:1:1: F401 '.decomposable.DecomposableIdentity' imported but unused
./torch_itl/model/__init__.py:3:5: F821 undefined name 'decomposable'
./torch_itl/estimator/utils.py:57:38: F821 undefined name 'sys'
./torch_itl/estimator/iqr.py:2:1: F401 '..model.DecomposableIdentity' imported but unused
./torch_itl/estimator/iqr.py:5:1: E302 expected 2 blank lines, found 1
./torch_itl/estimator/__init__.py:1:1: F401 '.vitl.VITL' imported but unused
./torch_itl/estimator/__init__.py:2:1: F401 '.emotransfer.EmoTransfer' imported but unused
./torch_itl/estimator/__init__.py:3:1: F401 '.iqr.IQR' imported but unused
./torch_itl/estimator/__init__.py:5:5: F821 undefined name 'vitl'
./torch_itl/estimator/__init__.py:6:5: F821 undefined name 'emotransfer'
./torch_itl/estimator/__init__.py:7:5: F821 undefined name 'iqr'
./torch_itl/estimator/vitl.py:109:80: E501 line too long (80 > 79 characters)
./torch_itl/kernel/__init__.py:1:1: F403 'from .kernel import *' used; unable to detect undefined names
./torch_itl/kernel/__init__.py:2:1: F403 'from .learnable import *' used; unable to detect undefined names
./torch_itl/kernel/__init__.py:4:1: F405 'GaussianRFF' may be undefined, or defined from star imports: .kernel, .learnable
./torch_itl/kernel/__init__.py:4:1: F405 'LearnableLinear' may be undefined, or defined from star imports: .kernel, .learnable
./torch_itl/kernel/__init__.py:4:1: F405 'Linear' may be undefined, or defined from star imports: .kernel, .learnable
./torch_itl/kernel/__init__.py:4:1: F405 'LearnableGaussianRFF' may be undefined, or defined from star imports: .kernel, .learnable
./torch_itl/kernel/__init__.py:4:1: F405 'LearnableKernel' may be undefined, or defined from star imports: .kernel, .learnable
./torch_itl/kernel/__init__.py:4:1: F405 'LearnableGaussian' may be undefined, or defined from star imports: .kernel, .learnable
./torch_itl/kernel/__init__.py:4:1: F405 'Gaussian' may be undefined, or defined from star imports: .kernel, .learnable
./torch_itl/kernel/__init__.py:7:5: F821 undefined name 'kernel'
./torch_itl/kernel/__init__.py:8:5: F821 undefined name 'learnable'
./torch_itl/kernel/learnable.py:1:1: F401 'torch' imported but unused
./torch_itl/datasets/__init__.py:1:1: F403 'from .datasets import *' used; unable to detect undefined names
./torch_itl/datasets/__init__.py:1:1: F401 '.datasets.*' imported but unused
./torch_itl/datasets/datasets.py:228:9: F841 local variable 'con_im' is assigned to but never used
./torch_itl/sampler/sampler.py:3:1: E302 expected 2 blank lines, found 1
./torch_itl/sampler/sampler.py:19:80: E501 line too long (103 > 79 characters)
./torch_itl/sampler/sampler.py:21:80: E501 line too long (94 > 79 characters)
./torch_itl/sampler/__init__.py:1:1: F401 '.sampler.LinearSampler' imported but unused
./torch_itl/sampler/__init__.py:2:1: F401 '.emo_sampler.CircularEmoSampler' imported but unused
./torch_itl/sampler/__init__.py:4:5: F821 undefined name 'sampler'
./torch_itl/sampler/__init__.py:5:5: F821 undefined name 'emo_sampler'
./demos/quantile/demo_synthetic.py:44:1: E265 block comment should start with '# '
./demos/quantile/demo_synthetic.py:49:25: E127 continuation line over-indented for visual indent
./demos/quantile/demo_synthetic.py:50:1: E265 block comment should start with '# '
./demos/quantile/demo_synthetic.py:96:1: E265 block comment should start with '# '
./demos/quantile/demo_synthetic.py:105:25: E127 continuation line over-indented for visual indent
./demos/emotion_transfer/missing_data.py:114:14: W605 invalid escape sequence '\l'
./demos/emotion_transfer/cross_validation.py:6:1: F401 'matplotlib.pyplot as plt' imported but unused
./demos/emotion_transfer/utils/facealigner.py:122:80: E501 line too long (83 > 79 characters)
./demos/emotion_transfer/utils/facealigner.py:140:80: E501 line too long (97 > 79 characters)
./demos/emotion_transfer/utils/facealigner.py:144:80: E501 line too long (92 > 79 characters)
./demos/emotion_transfer/utils/dlib_landmarks.py:4:1: F401 'glob' imported but unused
./demos/emotion_transfer/utils/dlib_landmarks.py:16:80: E501 line too long (100 > 79 characters)
```

I personnally don't like `import *` and prefer explicit statements. if you really want to keep it, ignore the error by adding `# noqa` on the corresponding lines 

